### PR TITLE
HW 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ akharc Platform repository
       NAME       READY   STATUS    RESTARTS   AGE
       frontend   1/1     Running   0          4s
 ## Как запустить проект:
-
+##
 ## Как проверить работоспособность:
 перейти по ссылке http://localhost:8080
 ## PR checklist:

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: akha/otus-frontend-k8s
+    name: frontend
+    resources: {}
+    env:
+    - name: PORT
+      value: "8080"
+    - name: PRODUCT_CATALOG_SERVICE_ADDR
+      value: "productcatalogservice:3550"
+    - name: CURRENCY_SERVICE_ADDR
+      value: "currencyservice:7000"
+    - name: CART_SERVICE_ADDR
+      value: "cartservice:7070"
+    - name: RECOMMENDATION_SERVICE_ADDR
+      value: "recommendationservice:8080"
+    - name: SHIPPING_SERVICE_ADDR
+      value: "shippingservice:50051"
+    - name: CHECKOUT_SERVICE_ADDR
+      value: "checkoutservice:5050"
+    - name: AD_SERVICE_ADDR
+      value: "adservice:9555"
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels: 
+    app: web
+spec:
+  initContainers:
+    - name: init-web
+      image: busybox:1.32
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  containers:
+    - name: web
+      image: akha/otus-k8s:latest
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  volumes:
+    - name: app
+      emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,12 @@
+FROM nginx:alpine
+RUN adduser -D -u 1001 -g www www && \
+    mkdir /app && \
+    mkdir /run/nginx && \
+    chown -R www:www /app &&\
+    chown -R www:www /run/nginx && \
+    chown -R www:www /var/log/nginx && \
+    chown -R www:www /var/cache/nginx
+COPY nginx.conf /etc/nginx/nginx.conf
+USER 1001
+EXPOSE 8000
+CMD ["nginx", "-g", "daemon off;"]

--- a/kubernetes-intro/web/nginx.conf
+++ b/kubernetes-intro/web/nginx.conf
@@ -1,0 +1,35 @@
+#user       www www;  ## Default: nobody
+worker_processes  2;  ## Default: 1
+error_log  /var/log/nginx/error.log;
+pid        /var/log/nginx/nginx.pid;
+worker_rlimit_nofile 8192;
+
+events {
+  worker_connections  1024;  ## Default: 1024
+}
+
+http {
+  include       /etc/nginx/mime.types;
+ 
+  default_type application/octet-stream;
+  log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+    '"$request" $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log   /var/log/nginx/access.log  main;
+  sendfile     on;
+  tcp_nopush   on;
+
+  server { # php/fastcgi
+    listen       8000;
+    server_name  localhost;
+    access_log   /var/log/nginx/domain1.access.log  main;
+#    index    index.html index.htm index.php;
+    root   /app;
+
+
+    location / {
+      autoindex on;
+      autoindex_exact_size on;
+    }
+  }
+}


### PR DESCRIPTION
# Выполнено ДЗ №1

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
1.Разберитесь почему все pod в namespace kube-system восстановились после удаления.
    1.а Pod coredns восстановился из-за использования механизма replica set, который восстанавливает его работу
    2.b Остальные поды - это static pods, работой которых управляет kubelet. kubelet заущен как сервис, соответственно, пока сервис работает - поды будут пересоздаваться.

    $ ls -l  /etc/kubernetes/manifests
    total 16
    -rw------- 1 root root 2476 May 13 17:31 etcd.yaml
    -rw------- 1 root root 3637 May 13 17:31 kube-apiserver.yaml
    -rw------- 1 root root 2951 May 13 17:31 kube-controller-manager.yaml
    -rw------- 1 root root 1441 May 13 17:31 kube-scheduler.yaml

    systemctl status kubelet

    ● kubelet.service - kubelet: The Kubernetes Node Agent
     Loaded: loaded (/usr/lib/systemd/system/kubelet.service; disabled; vendor preset: enabled)
    Drop-In: /etc/systemd/system/kubelet.service.d
             └─10-kubeadm.conf
     Active: active (running) since Sat 2023-05-13 17:31:02 UTC; 1h 1min ago
       Docs: http://kubernetes.io/docs/
    Main PID: 1243 (kubelet)
      Tasks: 11 (limit: 2218)
     Memory: 113.9M
     CGroup: /system.slice/kubelet.service
             └─1243 /var/lib/minikube/binaries/v1.26.3/kubelet --bootstrap-kubeconfig=/etc/kubernetes/bootstrap-kubelet.conf --config=/var/lib/kub
2. POD с веб-сервером
    2.а Был создан Dockerfile на основе образа nginx:alpine, c uid  1001, который слушает на порту 8000. Образ запушен в Докерхаб:
     docker build -t nginx-otus-k8s .
     docker tag nginx-otus-k8s akha/otus-k8s
     docker push akha/otus-k8s
    2.b Создан манифест пода с init-контейнером и volumes на основе образа из предыдущего пункта.Содержимое доступно по адресу http://localhost:8000/
     kubectl apply -f web-pod.yaml
     kubectl port-forward --address 0.0.0.0 pod/web 8000:8000
3. Hipster Shop
    3.а Склонирован репо microservices-demo, собран образ hipster-frontend, запушен в Докерхаб, сформирован манифест для пода:
     docker build -t hipster-frontend-k8s .
     docker tag hipster-frontend-k8s akha/otus-frontend-k8s
     docker push akha/otus-frontend-k8s
     kubectl run frontend --image akha/otus-frontend-k8s --restart=Never  --dry-run -o yaml > frontend-pod.yaml
    3.b ЗАДАНИЕ СО ЗВЕЗДОЧКОЙ. Под frontend не запускается, т.к. не описаны требуемые переменные окружения:
     panic: environment variable "PRODUCT_CATALOG_SERVICE_ADDR" not set
    Исправлено в манифесте frontend-pod-healthy.yaml
     kubectl apply -f frontend-pod-healthy.yaml
     [akha@192 kubernetes-intro]$ kubectl get pods
     NAME       READY   STATUS    RESTARTS   AGE
     frontend   1/1     Running   0          4s
## Как запустить проект:
 - Например, запустить команду X в директории Y

## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8080

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
