### PR TITLE
Kubernetes controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ akharc Platform repository
       NAME       READY   STATUS    RESTARTS   AGE
       frontend   1/1     Running   0          4s
 ## Как запустить проект:
-
+##
 ## Как проверить работоспособность:
 перейти по ссылке http://localhost:8080
 ## PR checklist:

--- a/kubernetes-controllers/README.md
+++ b/kubernetes-controllers/README.md
@@ -1,0 +1,98 @@
+# akharc_platform
+akharc Platform repository
+# Выполнено ДЗ №2
+
+ - [*] Основное ДЗ
+ - [*] Задание со *
+ - [*] Задание с **
+
+## В процессе сделано:
+- Запущен кластер с использованием kind
+- Развернуты поды frontend с использованием ReplicaSet
+- Развернуты поды frontend и paymentservice с использованием Deployment
+- Развернуты поды node-exporter с использованием DaemonSet
+- Проверены различные сценария деплоя (Blue-green, reverse Rolling Update)
+- Опробована работа с Probe
+
+1.Руководствуясь материалами лекции опишите произошедшую ситуацию, почему обновление ReplicaSet не повлекло обновление запущенных pod?
+
+Ответ:
+ReplicaSet не может рестартовать запущенные поды при обновлении шаблона, для этого инужно использовать Deployment.
+
+2. С использованием параметров maxSurge и maxUnavailable самостоятельно реализуйте два следующих сценария развертывания:
+Аналог blue-green
+Reverse Rolling Update
+    2.a BLUE-GREEN
+    
+```shell    
+    strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 3
+```
+    2.b Reverse Rolling Update
+    
+```shell    
+    strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+```
+
+
+3. DaemonSet
+
+    
+    3.a Подготовить манифест DaemonSet для node-exporter
+    Пример манифеста взят отсюда:
+    https://github.com/liukuan73/kubernetes-addons/blob/master/monitor/prometheus%2Bgrafana/node-exporter-daemonset.yaml
+    
+     После применения данного DaemonSet и выполнения команды:
+```shell
+kubectl port-forward node-exporter-69sp5  9100:9100
+```
+    метрики должны быть доступны на localhost: curl localhost:9100/metrics :
+
+```shell
+curl localhost:9100/metrics
+# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+# TYPE go_gc_duration_seconds summary
+go_gc_duration_seconds{quantile="0"} 0
+go_gc_duration_seconds{quantile="0.25"} 0
+go_gc_duration_seconds{quantile="0.5"} 0
+go_gc_duration_seconds{quantile="0.75"} 0
+go_gc_duration_seconds{quantile="1"} 0
+go_gc_duration_seconds_sum 0
+go_gc_duration_seconds_count 0
+# HELP go_goroutines Number of goroutines that currently exist.
+# TYPE go_goroutines gauge
+```
+    
+    
+    
+    3.b ЗАДАНИЕ СО ЗВЕЗДОЧКОЙ. Найдите способ модернизировать свой DaemonSet таким образом, чтобы Node Exporter был развернут как на master, так и на worker нодах.
+    
+    В качестве решения использован механизм tolerations:
+
+```shell
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        effect: "NoSchedule"
+```
+    
+## Как запустить проект:
+##
+## Как проверить работоспособность:
+```shell
+
+kubectl apply -f paymentservice-deployment-reverse.yaml | kubectl get pods -l app=paymentservice -w 
+kubectl apply -f paymentservice-deployment-bg.yaml | kubectl get pods -l app=paymentservice -w
+kubectl apply -f node-exporter-daemonset.yaml
+kubectl port-forward node-exporter-69sp5  9100:9100
+curl localhost:9100/metrics
+```
+
+## PR checklist:
+ - [*] Выставлен label с темой домашнего задания

--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -20,7 +20,7 @@ spec:
         readinessProbe:
           initialDelaySeconds: 10
           httpGet:
-            path: "/_health"
+            path: "/_healthz"
             port: 8080
             httpHeaders:
             - name: "Cookie"

--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: akha/otus-frontend-k8s:0.0.2
+        readinessProbe:
+          initialDelaySeconds: 10
+          httpGet:
+            path: "/_health"
+            port: 8080
+            httpHeaders:
+            - name: "Cookie"
+              value: "shop_session-id=x-readiness-probe"
+        env:
+        - name: PORT
+          value: "8080"
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: ENABLE_PROFILER
+          value: "0"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: frontend
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: frontend

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: frontend
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+      - name: server
+        image: akha/otus-frontend-k8s:0.0.2
+        env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "shippingservice:50051"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+        - name: ENABLE_PROFILER
+          value: "0"

--- a/kubernetes-controllers/node-exporter-daemonset.yaml
+++ b/kubernetes-controllers/node-exporter-daemonset.yaml
@@ -1,0 +1,32 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  labels:
+    app: node-exporter
+spec:
+  selector:
+    matchLabels:
+      app: node-exporter 
+  template:
+    metadata:
+      name: node-exporter
+      labels:
+        app: node-exporter
+    spec:
+      containers:
+      - image: prom/node-exporter:v0.16.0
+        imagePullPolicy: IfNotPresent
+        name: node-exporter
+        ports:
+        - name: prom-node-exp
+          #^ must be an IANA_SVC_NAME (at most 15 characters, ..)
+          containerPort: 9100
+          hostPort: 9100
+      tolerations:
+      - key: "node-role.kubernetes.io/master"
+        effect: "NoSchedule"
+      hostNetwork: true
+      hostPID: true
+      hostIPC: true
+      restartPolicy: Always

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: akha/paymentservice-k8s:0.0.2
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 1
+      maxSurge: 0
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: akha/paymentservice-k8s:0.0.2
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: akha/paymentservice-k8s:0.0.2
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-controllers/paymentservice-pod-healthy.yaml
+++ b/kubernetes-controllers/paymentservice-pod-healthy.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: paymentservice
+  name: paymentservice
+spec:
+  containers:
+  - image: akha/paymentservice-k8s:0.0.1
+    name: paymentservice
+    resources: {}
+    env:
+    - name: PORT
+      value: "50051"
+    - name: DISABLE_PROFILER
+      value: "1"
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: paymentservice
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+      - name: server
+        image: akha/paymentservice-k8s:0.0.1
+        env:
+        - name: PORT
+          value: "50051"
+        - name: DISABLE_PROFILER
+          value: "1"

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,32 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: akha/otus-frontend-k8s
+    name: frontend
+    resources: {}
+    env:
+    - name: PORT
+      value: "8080"
+    - name: PRODUCT_CATALOG_SERVICE_ADDR
+      value: "productcatalogservice:3550"
+    - name: CURRENCY_SERVICE_ADDR
+      value: "currencyservice:7000"
+    - name: CART_SERVICE_ADDR
+      value: "cartservice:7070"
+    - name: RECOMMENDATION_SERVICE_ADDR
+      value: "recommendationservice:8080"
+    - name: SHIPPING_SERVICE_ADDR
+      value: "shippingservice:50051"
+    - name: CHECKOUT_SERVICE_ADDR
+      value: "checkoutservice:5050"
+    - name: AD_SERVICE_ADDR
+      value: "adservice:9555"
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels: 
+    app: web
+spec:
+  initContainers:
+    - name: init-web
+      image: busybox:1.32
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  containers:
+    - name: web
+      image: akha/otus-k8s:latest
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  volumes:
+    - name: app
+      emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,12 @@
+FROM nginx:alpine
+RUN adduser -D -u 1001 -g www www && \
+    mkdir /app && \
+    mkdir /run/nginx && \
+    chown -R www:www /app &&\
+    chown -R www:www /run/nginx && \
+    chown -R www:www /var/log/nginx && \
+    chown -R www:www /var/cache/nginx
+COPY nginx.conf /etc/nginx/nginx.conf
+USER 1001
+EXPOSE 8000
+CMD ["nginx", "-g", "daemon off;"]

--- a/kubernetes-intro/web/nginx.conf
+++ b/kubernetes-intro/web/nginx.conf
@@ -1,0 +1,35 @@
+#user       www www;  ## Default: nobody
+worker_processes  2;  ## Default: 1
+error_log  /var/log/nginx/error.log;
+pid        /var/log/nginx/nginx.pid;
+worker_rlimit_nofile 8192;
+
+events {
+  worker_connections  1024;  ## Default: 1024
+}
+
+http {
+  include       /etc/nginx/mime.types;
+ 
+  default_type application/octet-stream;
+  log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+    '"$request" $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log   /var/log/nginx/access.log  main;
+  sendfile     on;
+  tcp_nopush   on;
+
+  server { # php/fastcgi
+    listen       8000;
+    server_name  localhost;
+    access_log   /var/log/nginx/domain1.access.log  main;
+#    index    index.html index.htm index.php;
+    root   /app;
+
+
+    location / {
+      autoindex on;
+      autoindex_exact_size on;
+    }
+  }
+}


### PR DESCRIPTION
# Выполнено ДЗ №2

 - [x] Основное ДЗ
 - [x] Задание со *
 - [x] Задание с **

## В процессе сделано:
- Запущен кластер с использованием kind
- Развернуты поды frontend с использованием ReplicaSet
- Развернуты поды frontend и paymentservice с использованием Deployment
- Развернуты поды node-exporter с использованием DaemonSet
- Проверены различные сценария деплоя (Blue-green, reverse Rolling Update)
- Опробована работа с Probe

## Задания

> 1.Руководствуясь материалами лекции опишите произошедшую ситуацию, почему обновление ReplicaSet не повлекло обновление запущенных pod?

Ответ:
ReplicaSet не может рестартовать запущенные поды при обновлении шаблона, для этого инужно использовать Deployment.


> 2. С использованием параметров maxSurge и maxUnavailable самостоятельно реализуйте два следующих сценария развертывания:

Аналог blue-green
Reverse Rolling Update

>2.a BLUE-GREEN

```
 strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 0
      maxSurge: 3
```

> 2.b Reverse Rolling Update

   
```
 strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 1
      maxSurge: 0
```


> 3. DaemonSet

>  3.a Подготовить манифест DaemonSet для node-exporter

    Пример манифеста взят отсюда:
    [github](https://github.com/liukuan73/kubernetes-addons/blob/master/monitor/prometheus%2Bgrafana/node-exporter-daemonset.yaml)

     После применения данного DaemonSet и выполнения команды:
```shell
kubectl port-forward node-exporter-69sp5  9100:9100
```
    метрики должны быть доступны на localhost: curl localhost:9100/metrics :

```shell
curl localhost:9100/metrics
# HELP go_gc_duration_seconds A summary of the GC invocation durations.
# TYPE go_gc_duration_seconds summary
go_gc_duration_seconds{quantile="0"} 0
go_gc_duration_seconds{quantile="0.25"} 0
go_gc_duration_seconds{quantile="0.5"} 0
go_gc_duration_seconds{quantile="0.75"} 0
go_gc_duration_seconds{quantile="1"} 0
go_gc_duration_seconds_sum 0
go_gc_duration_seconds_count 0
# HELP go_goroutines Number of goroutines that currently exist.
# TYPE go_goroutines gauge
```



> 3.b ЗАДАНИЕ СО ЗВЕЗДОЧКОЙ. Найдите способ модернизировать свой DaemonSet таким образом, чтобы Node Exporter был развернут как на master, так и на worker нодах.

    В качестве решения использован механизм tolerations:

```shell
      tolerations:
      - key: "node-role.kubernetes.io/master"
        effect: "NoSchedule"
```

## Как запустить проект:
##
## Как проверить работоспособность:
```shell
kubectl apply -f paymentservice-deployment-reverse.yaml | kubectl get pods -l app=paymentservice -w 
kubectl apply -f paymentservice-deployment-bg.yaml | kubectl get pods -l app=paymentservice -w
kubectl apply -f node-exporter-daemonset.yaml
kubectl port-forward node-exporter-69sp5  9100:9100
curl localhost:9100/metrics
```


## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
