### PR TITLE
HW3

### DIFF
--- a/kubernetes-networks/README.md
+++ b/kubernetes-networks/README.md
@@ -1,0 +1,215 @@
+# akharc_platform
+akharc Platform repository
+# Выполнено ДЗ №3
+
+ - [ ] Основное ДЗ
+ - [ ] Задание со *
+
+## В процессе сделано:
+- Созданы Service Cluster IP и HeadlessService, LoadBalanser , Ingress
+- Со *: выполнены задания Coredns, ingress dashboard, ingress canary 
+
+## Как проверить работоспособность:
+task01 добавляем Readiness и liveness probe в под из 1-го ДЗ
+
+Вопрос для самопроверки:  Почему следующая конфигурация валидна, но не имеет смысла?
+ livenessProbe:    exec:     command:        - 'sh'        - '-c'        - 'ps aux | grep my_web_server_process'
+Потому что команда всегда вернет ненулевой результат
+Бывают ли ситуации, когда она все-таки имеет смысл?
+Да, например в случае, если контейнер повиснет и не сможет вернуть результат
+
+
+Устанавливаем Service с ClusterIP:
+
+```shell
+
+kubectl apply -f web-svc-cip.yaml
+kubectl get services
+
+web-svc-cip   ClusterIP   10.101.3.254    <none>        80/TCP    14s
+```
+
+---
+task02 Metallb
+  Ставим актуальную версию по официальной инструкции:
+```shell
+kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.10/config/manifests/metallb-native.yaml
+
+kubectl --namespace metallb-system get all
+NAME                              READY   STATUS    RESTARTS   AGE
+pod/controller-5fd797fbf7-x8zb4   1/1     Running   0          3m54s
+pod/speaker-hv4lp                 1/1     Running   0          3m54s
+
+NAME                      TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
+service/webhook-service   ClusterIP   10.104.27.230   <none>        443/TCP   3m54s
+
+NAME                     DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
+daemonset.apps/speaker   1         1         1       1            1           kubernetes.io/os=linux   17h
+
+NAME                         READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/controller   1/1     1            1           17h
+
+NAME                                    DESIRED   CURRENT   READY   AGE
+replicaset.apps/controller-56986fbff6   0         0         0       17h
+replicaset.apps/controller-5fd797fbf7   1         1         1       3m54s
+
+[akha@192 kubernetes-networks]$ kubectl apply -f web-svc-lb.yaml
+
+kubectl --namespace metallb-system logs pod/controller-5fd797fbf7-x8zb4 
+
+kubectl describe svc web-svc-lb
+Normal   IPAllocated       13s    metallb-controller  Assigned IP ["172.17.255.1"]
+
+
+eth0      Link encap:Ethernet  HWaddr 52:54:00:28:66:D8
+          inet addr:192.168.39.198  Bcast:192.168.39.255  Mask:255.255.255.0
+
+
+sudo route add -net 172.17.255.0 netmask 255.255.255.0 gw 192.168.39.198
+```
+Задание Со *:  Coredns
+Выполняем по инструкции из https://metallb.universe.tf/usage/
+
+---
+task03 Ingress
+```shell
+akubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/baremetal/deploy.yaml
+
+[akha@192 kubernetes-networks]$ kubectl apply -f nginx-lb.yaml
+service/ingress-nginx created
+
+[akha@192 kubernetes-networks]$ kubectl get services --namespace=ingress-nginx
+NAME                                 TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
+ingress-nginx                        LoadBalancer   10.100.85.51    172.17.255.2   80:30295/TCP,443:30912/TCP   15s
+
+
+[akha@192 kubernetes-networks]$ kubectl apply -f web-svc-headless.yaml
+web-svc       ClusterIP      None             <none>         80/TCP         10s
+```
+Инфо в методичке неактуально, рабочий пример манифеста:
+https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/#create-an-ingress
+добавить ingressClassName: nginx-example 
+```shell
+kubectl apply -f web-ingress.yaml
+[akha@192 kubernetes-networks]$ kubectl describe ingress/web
+Name:             web
+Labels:           <none>
+Namespace:        default
+Address:          192.168.39.198
+Ingress Class:    nginx
+Default backend:  <default>
+Rules:
+  Host        Path  Backends
+  ----        ----  --------
+  *
+              /web   web-svc:8000 (10.244.0.10:8000,10.244.0.12:8000,10.244.0.9:8000)
+Annotations:  nginx.ingress.kubernetes.io/rewrite-target: /$1
+Events:
+  Type    Reason  Age                 From                      Message
+  ----    ------  ----                ----                      -------
+  Normal  Sync    2m (x2 over 2m14s)  nginx-ingress-controller  Scheduled for sync
+```
+---
+Задание со * - Dashboard:
+В соответствии с инструкцией создаем сервис-аккаунт и роль:
+```shell
+[akha@192 dashboard]$ kubectl apply -f sa.yaml
+serviceaccount/admin-user created
+
+[akha@192 dashboard]$ kubectl apply -f role.yaml
+clusterrolebinding.rbac.authorization.k8s.io/admin-user created
+```
+
+Ставим актуальную версию dashboard
+```shell
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml
+```
+
+Настраиваем ingress
+```shell
+[akha@192 dashboard]$ kubectl apply -f dashboard-svc-headless.yaml
+service/dashboard-svc created
+
+kubectl apply -f dashboard-ingress.yaml
+ingress.networking.k8s.io/dashboard created
+[akha@192 dashboard]$ kubectl describe ingress/dashboard
+Name:             dashboard
+Labels:           <none>
+Namespace:        default
+Address:          192.168.39.198
+Ingress Class:    nginx
+Default backend:  <default>
+Rules:
+  Host        Path  Backends
+  ----        ----  --------
+  *
+              /dashboard   dashboard-svc:8080 (<none>)
+Annotations:  nginx.ingress.kubernetes.io/backend-protocol: HTTP
+              nginx.ingress.kubernetes.io/rewrite-target: /$1
+Events:
+  Type    Reason  Age               From                      Message
+  ----    ------  ----              ----                      -------
+  Normal  Sync    9s (x2 over 19s)  nginx-ingress-controller  Scheduled for sync
+```
+проверяем:
+```shell
+kubectl apply -f canary-ingress.yaml
+```
+```shell
+curl -i http://172.17.255.2/dashboard
+```
+```shell
+HTTP/1.1 200 OK
+Date: Sun, 25 Jun 2023 13:37:33 GMT
+Content-Type: text/html; charset=utf-8
+Content-Length: 1412
+Connection: keep-alive
+Accept-Ranges: bytes
+Cache-Control: no-cache, no-store, must-revalidate
+Last-Modified: Fri, 16 Sep 2022 11:49:34 GMT
+
+
+--><!DOCTYPE html><html lang="en" dir="ltr"><head>
+  <meta charset="utf-8">
+  <title>Kubernetes Dashboard</title>
+  <link rel="icon" type="image/png" href="assets/images/kubernetes-logo.png">
+  <meta name="viewport" content="width=device-width">
+```
+---
+Задание со * канарейка:
+Добавляем в манифест ингресса анотации для маршрутизации через заголовки:
+nginx.ingress.kubernetes.io/canary	"true" or "false"
+nginx.ingress.kubernetes.io/canary-by-header	string
+nginx.ingress.kubernetes.io/canary-by-header-value	string
+
+Применяем манифесты деплоймента, сервиса и ингресса и проверяем:
+
+```shell
+[akha@192 canary]$ kubectl describe ingress canary
+Name:             canary
+Labels:           <none>
+Namespace:        default
+Address:          192.168.39.198
+Ingress Class:    nginx
+Default backend:  <default>
+Rules:
+  Host        Path  Backends
+  ----        ----  --------
+  *
+              /   svc-canary:8000 ()
+Annotations:  nginx.ingress.kubernetes.io/canary: true
+              nginx.ingress.kubernetes.io/canary-by-header: ver
+              nginx.ingress.kubernetes.io/canary-by-header-value: canary
+              nginx.ingress.kubernetes.io/rewrite-target: /$1
+Events:
+  Type    Reason  Age                    From                      Message
+  ----    ------  ----                   ----                      -------
+  Normal  Sync    6m24s (x2 over 7m17s)  nginx-ingress-controller  Scheduled for sync
+
+```
+Проверяем командой
+```shell
+curl -i 172.17.255.2/web -H "ver: canary"
+```
+## PR checklist:
+ - [*] Выставлен label с темой домашнего задания

--- a/kubernetes-networks/canary/Dockerfile
+++ b/kubernetes-networks/canary/Dockerfile
@@ -1,0 +1,13 @@
+FROM nginx:alpine
+RUN adduser -D -u 1001 -g www www && \
+    mkdir /app && \
+    mkdir /run/nginx && \
+    chown -R www:www /app &&\
+    chown -R www:www /run/nginx && \
+    chown -R www:www /var/log/nginx && \
+    chown -R www:www /var/cache/nginx
+RUN wget -O- https://tinyurl.com/otus-k8s-intro | sh
+COPY nginx.conf /etc/nginx/nginx.conf
+USER 1001
+EXPOSE 8000
+CMD ["nginx", "-g", "daemon off;"]

--- a/kubernetes-networks/canary/canary-ingress.yaml
+++ b/kubernetes-networks/canary/canary-ingress.yaml
@@ -1,0 +1,21 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: canary
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/canary: "true"
+    nginx.ingress.kubernetes.io/canary-by-header: "ver"
+    nginx.ingress.kubernetes.io/canary-by-header-value: "canary"
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: svc-canary
+            port:
+              number: 8000

--- a/kubernetes-networks/canary/canary-svc-headless.yaml
+++ b/kubernetes-networks/canary/canary-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: svc-canary
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/canary/nginx.conf
+++ b/kubernetes-networks/canary/nginx.conf
@@ -1,0 +1,35 @@
+#user       www www;  ## Default: nobody
+worker_processes  2;  ## Default: 1
+error_log  /var/log/nginx/error.log;
+pid        /var/log/nginx/nginx.pid;
+worker_rlimit_nofile 8192;
+
+events {
+  worker_connections  1024;  ## Default: 1024
+}
+
+http {
+  include       /etc/nginx/mime.types;
+ 
+  default_type application/octet-stream;
+  log_format   main '$remote_addr - $remote_user [$time_local]  $status '
+    '"$request" $body_bytes_sent "$http_referer" '
+    '"$http_user_agent" "$http_x_forwarded_for"';
+  access_log   /var/log/nginx/access.log  main;
+  sendfile     on;
+  tcp_nopush   on;
+
+  server { # php/fastcgi
+    listen       8000;
+    server_name  localhost;
+    access_log   /var/log/nginx/domain1.access.log  main;
+#    index    index.html index.htm index.php;
+    root   /app;
+
+
+    location / {
+      autoindex on;
+      autoindex_exact_size on;
+    }
+  }
+}

--- a/kubernetes-networks/canary/web-deploy.yaml
+++ b/kubernetes-networks/canary/web-deploy.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: canary
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%
+  selector:
+    matchLabels:
+      app: canary
+  template:
+    metadata:
+      labels:
+        app: canary
+    spec:
+      containers:
+      - name: canary
+        image:  akha/otus-k8s:canary
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        volumeMounts:
+          - name: app
+            mountPath: /app
+      initContainers:
+        - name: init-web
+          image: busybox:1.32
+          command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro  | sh']
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          emptyDir: {}

--- a/kubernetes-networks/canary/web-pod-1.yaml
+++ b/kubernetes-networks/canary/web-pod-1.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels: 
+    app: web
+spec:
+  initContainers:
+    - name: init-web
+      image: busybox:1.28
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  containers:
+    - name: web
+      image: akha/otus-k8s:canary
+      readinessProbe:
+#        initialDelaySeconds: 10
+        httpGet:
+          path: /index.html
+          port: 80
+      livenessProbe:
+        tcpSocket: { port: 8000 }    
+
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  volumes:
+    - name: app
+      emptyDir: {}

--- a/kubernetes-networks/coredns/dns-svc-lb.yaml
+++ b/kubernetes-networks/coredns/dns-svc-lb.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-service-tcp
+  namespace: default
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "dns-svc-ip"
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.2
+  ports:
+    - name: dnstcp
+      protocol: TCP
+      port: 53
+      targetPort: 53
+  selector:
+    app: dns
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dns-svc-udp
+  namespace: default
+  annotations:
+    metallb.universe.tf/allow-shared-ip: "dns-svc-ip"
+spec:
+  type: LoadBalancer
+  loadBalancerIP: 172.17.255.2
+  ports:
+    - name: dnsudp
+      protocol: UDP
+      port: 53
+      targetPort: 53
+  selector:
+    app: dns    

--- a/kubernetes-networks/dashboard/dashboard-ingress.yaml
+++ b/kubernetes-networks/dashboard/dashboard-ingress.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  namespace: kubernetes-dashboard
+  name: dashboard
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - path: /dashboard
+        pathType: Prefix
+        backend:
+          service:
+            name: kubernetes-dashboard
+            port:
+              number: 8443

--- a/kubernetes-networks/dashboard/dashboard-svc-headless.yaml
+++ b/kubernetes-networks/dashboard/dashboard-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: dashboard-svc
+spec:
+  selector:
+    k8s-app: kubernetes-dashboard
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8443

--- a/kubernetes-networks/dashboard/role.yaml
+++ b/kubernetes-networks/dashboard/role.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernetes-dashboard
+  namespace: kubernetes-dashboard
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+  - kind: ServiceAccount
+    name: kubernetes-dashboard
+    namespace: kubernetes-dashboard

--- a/kubernetes-networks/dashboard/sa.yaml
+++ b/kubernetes-networks/dashboard/sa.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: admin-user
+  namespace: kubernetes-dashboard

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: first-pool
+  namespace: metallb-system
+spec:
+  addresses:
+  - 172.17.255.1-172.17.255.255

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,17 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+    - { name: http, port: 80, targetPort: http }
+    - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 100%
+      maxSurge: 100%
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      labels:
+        app: web
+    spec:
+      containers:
+      - name: web
+        image:  akha/otus-k8s:latest
+        livenessProbe:
+          tcpSocket:
+            port: 8000
+        readinessProbe:
+          httpGet:
+            path: /index.html
+            port: 8000
+        volumeMounts:
+          - name: app
+            mountPath: /app
+      initContainers:
+        - name: init-web
+          image: busybox:musl
+          command: ['sh', '-c', 'wget -O- https://bit.ly/otus-k8s-index-gen | sh']
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          emptyDir: {}

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  ingressClassName: nginx
+  rules:
+  - http:
+      paths:
+      - path: /web
+        pathType: Prefix
+        backend:
+          service:
+            name: web-svc
+            port:
+              number: 8000

--- a/kubernetes-networks/web-pod.yaml
+++ b/kubernetes-networks/web-pod.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels: 
+    app: web
+spec:
+  initContainers:
+    - name: init-web
+      image: busybox:1.32
+      command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  containers:
+    - name: web
+      image: akha/otus-k8s:latest
+      readinessProbe:
+#        initialDelaySeconds: 10
+        httpGet:
+          path: /index.html
+          port: 80
+      livenessProbe:
+        tcpSocket: { port: 8000 }    
+
+      volumeMounts:
+        - name: app
+          mountPath: /app
+  volumes:
+    - name: app
+      emptyDir: {}

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
# akharc_platform
akharc Platform repository
# Выполнено ДЗ №3

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:
- Созданы Service Cluster IP и HeadlessService, LoadBalanser , Ingress
- Со *: выполнены задания Coredns, ingress dashboard, ingress canary 

## Как проверить работоспособность:
- task01 добавляем Readiness и liveness probe в под из 1-го ДЗ

Вопрос для самопроверки:  Почему следующая конфигурация валидна, но не имеет смысла?
 livenessProbe:    exec:     command:        - 'sh'        - '-c'        - 'ps aux | grep my_web_server_process'
Потому что команда всегда вернет ненулевой результат
Бывают ли ситуации, когда она все-таки имеет смысл?
Да, например в случае, если контейнер повиснет и не сможет вернуть результат


Устанавливаем Service с ClusterIP:

```shell

kubectl apply -f web-svc-cip.yaml
kubectl get services

web-svc-cip   ClusterIP   10.101.3.254    <none>        80/TCP    14s
```

- task02 Metallb
  Ставим актуальную версию по официальной инструкции:
```shell
kubectl apply -f https://raw.githubusercontent.com/metallb/metallb/v0.13.10/config/manifests/metallb-native.yaml

kubectl --namespace metallb-system get all
NAME                              READY   STATUS    RESTARTS   AGE
pod/controller-5fd797fbf7-x8zb4   1/1     Running   0          3m54s
pod/speaker-hv4lp                 1/1     Running   0          3m54s

NAME                      TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
service/webhook-service   ClusterIP   10.104.27.230   <none>        443/TCP   3m54s

NAME                     DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR            AGE
daemonset.apps/speaker   1         1         1       1            1           kubernetes.io/os=linux   17h

NAME                         READY   UP-TO-DATE   AVAILABLE   AGE
deployment.apps/controller   1/1     1            1           17h

NAME                                    DESIRED   CURRENT   READY   AGE
replicaset.apps/controller-56986fbff6   0         0         0       17h
replicaset.apps/controller-5fd797fbf7   1         1         1       3m54s

[akha@192 kubernetes-networks]$ kubectl apply -f web-svc-lb.yaml

kubectl --namespace metallb-system logs pod/controller-5fd797fbf7-x8zb4 

kubectl describe svc web-svc-lb
Normal   IPAllocated       13s    metallb-controller  Assigned IP ["172.17.255.1"]


eth0      Link encap:Ethernet  HWaddr 52:54:00:28:66:D8
          inet addr:192.168.39.198  Bcast:192.168.39.255  Mask:255.255.255.0


sudo route add -net 172.17.255.0 netmask 255.255.255.0 gw 192.168.39.198
```
- Задание Со *:  Coredns
Выполняем по инструкции из https://metallb.universe.tf/usage/

- task03 Ingress
```shell
akubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/provider/baremetal/deploy.yaml

[akha@192 kubernetes-networks]$ kubectl apply -f nginx-lb.yaml
service/ingress-nginx created

[akha@192 kubernetes-networks]$ kubectl get services --namespace=ingress-nginx
NAME                                 TYPE           CLUSTER-IP      EXTERNAL-IP    PORT(S)                      AGE
ingress-nginx                        LoadBalancer   10.100.85.51    172.17.255.2   80:30295/TCP,443:30912/TCP   15s


[akha@192 kubernetes-networks]$ kubectl apply -f web-svc-headless.yaml
web-svc       ClusterIP      None             <none>         80/TCP         10s
```
Инфо в методичке неактуально, рабочий пример манифеста:
https://kubernetes.io/docs/tasks/access-application-cluster/ingress-minikube/#create-an-ingress
добавить ingressClassName: nginx-example 
```shell
kubectl apply -f web-ingress.yaml
[akha@192 kubernetes-networks]$ kubectl describe ingress/web
Name:             web
Labels:           <none>
Namespace:        default
Address:          192.168.39.198
Ingress Class:    nginx
Default backend:  <default>
Rules:
  Host        Path  Backends
  ----        ----  --------
  *
              /web   web-svc:8000 (10.244.0.10:8000,10.244.0.12:8000,10.244.0.9:8000)
Annotations:  nginx.ingress.kubernetes.io/rewrite-target: /$1
Events:
  Type    Reason  Age                 From                      Message
  ----    ------  ----                ----                      -------
  Normal  Sync    2m (x2 over 2m14s)  nginx-ingress-controller  Scheduled for sync
```

- Задание со * - Dashboard:
В соответствии с инструкцией создаем сервис-аккаунт и роль:
```shell
[akha@192 dashboard]$ kubectl apply -f sa.yaml
serviceaccount/admin-user created

[akha@192 dashboard]$ kubectl apply -f role.yaml
clusterrolebinding.rbac.authorization.k8s.io/admin-user created
```

Ставим актуальную версию dashboard
```shell
kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.7.0/aio/deploy/recommended.yaml
```

Настраиваем ingress
```shell
[akha@192 dashboard]$ kubectl apply -f dashboard-svc-headless.yaml
service/dashboard-svc created

kubectl apply -f dashboard-ingress.yaml
ingress.networking.k8s.io/dashboard created
[akha@192 dashboard]$ kubectl describe ingress/dashboard
Name:             dashboard
Labels:           <none>
Namespace:        default
Address:          192.168.39.198
Ingress Class:    nginx
Default backend:  <default>
Rules:
  Host        Path  Backends
  ----        ----  --------
  *
              /dashboard   dashboard-svc:8080 (<none>)
Annotations:  nginx.ingress.kubernetes.io/backend-protocol: HTTP
              nginx.ingress.kubernetes.io/rewrite-target: /$1
Events:
  Type    Reason  Age               From                      Message
  ----    ------  ----              ----                      -------
  Normal  Sync    9s (x2 over 19s)  nginx-ingress-controller  Scheduled for sync
```
проверяем:
```shell
kubectl apply -f canary-ingress.yaml
```
```shell
curl -i http://172.17.255.2/dashboard
```
```shell
HTTP/1.1 200 OK
Date: Sun, 25 Jun 2023 13:37:33 GMT
Content-Type: text/html; charset=utf-8
Content-Length: 1412
Connection: keep-alive
Accept-Ranges: bytes
Cache-Control: no-cache, no-store, must-revalidate
Last-Modified: Fri, 16 Sep 2022 11:49:34 GMT


--><!DOCTYPE html><html lang="en" dir="ltr"><head>
  <meta charset="utf-8">
  <title>Kubernetes Dashboard</title>
  <link rel="icon" type="image/png" href="assets/images/kubernetes-logo.png">
  <meta name="viewport" content="width=device-width">
```

- Задание со * канарейка:
Добавляем в манифест ингресса анотации для маршрутизации через заголовки:
nginx.ingress.kubernetes.io/canary	"true" or "false"
nginx.ingress.kubernetes.io/canary-by-header	string
nginx.ingress.kubernetes.io/canary-by-header-value	string

Применяем манифесты деплоймента, сервиса и ингресса и проверяем:

```shell
[akha@192 canary]$ kubectl describe ingress canary
Name:             canary
Labels:           <none>
Namespace:        default
Address:          192.168.39.198
Ingress Class:    nginx
Default backend:  <default>
Rules:
  Host        Path  Backends
  ----        ----  --------
  *
              /   svc-canary:8000 ()
Annotations:  nginx.ingress.kubernetes.io/canary: true
              nginx.ingress.kubernetes.io/canary-by-header: ver
              nginx.ingress.kubernetes.io/canary-by-header-value: canary
              nginx.ingress.kubernetes.io/rewrite-target: /$1
Events:
  Type    Reason  Age                    From                      Message
  ----    ------  ----                   ----                      -------
  Normal  Sync    6m24s (x2 over 7m17s)  nginx-ingress-controller  Scheduled for sync

```
Проверяем командой
```shell
curl -i 172.17.255.2/web -H "ver: canary"
```
## PR checklist:
 - [*] Выставлен label с темой домашнего задания
